### PR TITLE
fix issue autorelease will not release trigger by autorelease.

### DIFF
--- a/cocos/base/CCAutoreleasePool.cpp
+++ b/cocos/base/CCAutoreleasePool.cpp
@@ -65,11 +65,12 @@ void AutoreleasePool::clear()
 #if defined(COCOS2D_DEBUG) && (COCOS2D_DEBUG > 0)
     _isClearing = true;
 #endif
-    for (const auto &obj : _managedObjectArray)
+    std::vector<Ref*> releasings;
+    releasings.swap(_managedObjectArray);
+    for (const auto &obj : releasings)
     {
         obj->release();
     }
-    _managedObjectArray.clear();
 #if defined(COCOS2D_DEBUG) && (COCOS2D_DEBUG > 0)
     _isClearing = false;
 #endif


### PR DESCRIPTION
I have found the problem in autoreleasepool. If i call an object's (A) autorelease in another's(B) destructor triggered by B's autorelease. The A will never release.
The reason is the B is destructed by calling release in AutoReleasePool::clear(). Autorelease function called in for loop.
It mean that the A will insert into _managedObjectArray in for loop of _managedObjectArray. So A will not be reached.
And then _managedObjectArray will be cleared after the for loop. So A object's release will not call.